### PR TITLE
Process Pester test plus SD parameter rework

### DIFF
--- a/SMBSecurity.psd1
+++ b/SMBSecurity.psd1
@@ -85,8 +85,8 @@ ScriptsToProcess = @('.\bin\class.ps1',
 # Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
 FunctionsToExport = @(# GET
                       'Get-SMBSecurity',
-                      'Get-SMBSecurityDescriptorNames',
-                      'Get-SMBSecurityDescriptorRights',
+                      'Get-SMBSecurityDescriptorName',
+                      'Get-SMBSecurityDescriptorRight',
                       'Get-SMBSecurityDescription',
                       # SET
                       'Set-SMBSecurityOwner',

--- a/tests/New.Tests.ps1
+++ b/tests/New.Tests.ps1
@@ -42,6 +42,8 @@ BeforeAll {
             return ( Write-Error "Failed to load file $($file.FullName): $_" -EA Stop )
         }
     }
+
+    $Script:backup = Backup-SMBSecurity -Path C:\Temp -RegOnly -FilePassThru | Where-Object { $_ -match "^.*\.reg$"}
 }
 
 
@@ -274,10 +276,10 @@ Describe 'New-SMBSecurityDACL' {
         It 'Creating a DACL for SrvsvcDefaultShareInfo' {
             
             $DACLSplat = @{
-                SecurityDescriptor = 'SrvsvcDefaultShareInfo'
-                Access             = 'Allow'
-                Right              = @('Change', 'Read')
-                Account            = "Administrator"
+                SecurityDescriptorName = 'SrvsvcDefaultShareInfo'
+                Access                 = 'Allow'
+                Right                  = @('Change', 'Read')
+                Account                = "Administrator"
             }
             
 
@@ -302,10 +304,10 @@ Describe 'New-SMBSecurityDACL' {
         It 'Other writes are ignored when FullControl is used.' {
             
             $DACLSplat = @{
-                SecurityDescriptor = 'SrvsvcDefaultShareInfo'
-                Access             = 'Allow'
-                Right              = @('Change', 'Read', 'FullControl')
-                Account            = "Administrator"
+                SecurityDescriptorName = 'SrvsvcDefaultShareInfo'
+                Access                 = 'Allow'
+                Right                  = @('Change', 'Read', 'FullControl')
+                Account                = "Administrator"
             }
             
 
@@ -332,10 +334,10 @@ Describe 'New-SMBSecurityDACL' {
         It 'Creating a DACL for SrvsvcDefaultShareInfo' {
             
             $DACLSplat = @{
-                SecurityDescriptor = 'SrvsvcDefaultShareInfo'
-                Access             = 'Allow'
-                Right              = @('Change', 'Read', 'Cheese')
-                Account            = "Administrator"
+                SecurityDescriptorName = 'SrvsvcDefaultShareInfo'
+                Access                 = 'Allow'
+                Right                  = @('Change', 'Read', 'Cheese')
+                Account                = "Administrator"
             }
             
 
@@ -530,4 +532,9 @@ Describe 'New-SMBSecurityDescriptor' {
             $SD.DACL.Right | Should -Contain "FullControl"
         }
     }
+}
+
+AfterAll {
+    Restore-SMBSecurity -File $Script:backup
+    Remove-Item $Script:backup -Force
 }

--- a/tests/Set.Tests.ps1
+++ b/tests/Set.Tests.ps1
@@ -44,7 +44,9 @@ BeforeAll {
     }
 
     # used in all tests
-    $Script:SMBSec = Get-SMBSecurity -SecurityDescriptor SrvsvcDefaultShareInfo
+    $Script:SMBSec = Get-SMBSecurity -SecurityDescriptorName SrvsvcDefaultShareInfo
+
+    $Script:backup = Backup-SMBSecurity -Path C:\Temp -RegOnly -FilePassThru | Where-Object { $_ -match "^.*\.reg$"}
 }
 
 Describe 'Set-SMBSecurityOwner' {
@@ -130,7 +132,7 @@ Describe 'Set-SMBSecurityGroup' {
 Describe 'Set-SMBSecurityDACL and Set-SmbSecurityDescriptorDACL' {
     Context " Modify the DACL (rights) of a SecurityDescriptor" {
         It " Change Access." {
-            $Script:SMBSec = Get-SMBSecurity -SecurityDescriptor SrvsvcSharePrintInfo
+            $Script:SMBSec = Get-SMBSecurity -SecurityDescriptorName SrvsvcSharePrintInfo
 
             $DACL = $Script:SMBSec.DACL[4]
             $NewDACL = Copy-SMBSecurityDACL $DACL
@@ -146,7 +148,7 @@ Describe 'Set-SMBSecurityDACL and Set-SmbSecurityDescriptorDACL' {
         }
 
         It " Change Rights." {
-            $Script:SMBSec = Get-SMBSecurity -SecurityDescriptor SrvsvcSharePrintInfo
+            $Script:SMBSec = Get-SMBSecurity -SecurityDescriptorName SrvsvcSharePrintInfo
 
             $DACL = $Script:SMBSec.DACL[4]
             $NewDACL = Copy-SMBSecurityDACL $DACL
@@ -161,7 +163,7 @@ Describe 'Set-SMBSecurityDACL and Set-SmbSecurityDescriptorDACL' {
         }
 
         It " Change Account." {
-            $Script:SMBSec = Get-SMBSecurity -SecurityDescriptor SrvsvcSharePrintInfo
+            $Script:SMBSec = Get-SMBSecurity -SecurityDescriptorName SrvsvcSharePrintInfo
 
             $DACL = $Script:SMBSec.DACL[4]
             $NewDACL = Copy-SMBSecurityDACL $DACL
@@ -173,4 +175,9 @@ Describe 'Set-SMBSecurityDACL and Set-SmbSecurityDescriptorDACL' {
             $SMBSec.DACL[4].Account.Account.Value | Should -Be "NT AUTHORITY\Authenticated Users"
         }
     }
+}
+
+AfterAll {
+    Restore-SMBSecurity -File $Script:backup
+    Remove-Item $Script:backup -Force
 }


### PR DESCRIPTION
Added two more base tests to Process.Test.ps1.

Changed parameters on key cmdlets. This will hopefully make it easier to determine whether a string name or SD object are needed.

Cmdlets that take a string SD name now use -SecurityDescriptorName with aliases: "SD","SecurityDescriptor","SDName","Name".

These are:

- Get-SMBSecurity
- Get-SMBSecurityDescription
- Get-SMBSecurityDescriptorRight
- New-SMBSecurityDACL
- Backup-SMBSecurity


Cmdlets that need a SMB SecurityDescriptor object (from Get-SMBSecurity) use -SecurityDescriptor.


Backup-SMBSecurity:
- Fixed an issue where backups of individual SDs was failing.
- Added a FilePassThru switch parameter which outputs the full path to each backup created. This should be handy for automation of backup file copy/move operations.