### PR TITLE
Backup path params to Save

### DIFF
--- a/tests/Get.Tests.ps1
+++ b/tests/Get.Tests.ps1
@@ -150,5 +150,16 @@ Describe 'Get-SMBSecurityDescriptorRight' {
 
 AfterAll {
     Restore-SMBSecurity -File $Script:backup
-    Remove-Item $Script:backup -Force
+    
+    # do file cleanup so it doesn't interfere with other tests
+    $paths = "C:\Temp",  "$ENV:LOCALAPPDATA\SMBSecurity"
+
+    foreach ($path in $paths)
+    {
+        $files = Get-ChildItem "$path" -Filter "SMBSec-*.reg"
+        $files | ForEach-Object { Remove-Item $_.FullName -Force }
+
+        $files = Get-ChildItem "$path" -Filter "Backup-*-SMBSec-*.xml"
+        $files | ForEach-Object { Remove-Item $_.FullName -Force }
+    }   
 }

--- a/tests/New.Tests.ps1
+++ b/tests/New.Tests.ps1
@@ -536,5 +536,16 @@ Describe 'New-SMBSecurityDescriptor' {
 
 AfterAll {
     Restore-SMBSecurity -File $Script:backup
-    Remove-Item $Script:backup -Force
+    
+    # do file cleanup so it doesn't interfere with other tests
+    $paths = "C:\Temp",  "$ENV:LOCALAPPDATA\SMBSecurity"
+
+    foreach ($path in $paths)
+    {
+        $files = Get-ChildItem "$path" -Filter "SMBSec-*.reg"
+        $files | ForEach-Object { Remove-Item $_.FullName -Force }
+
+        $files = Get-ChildItem "$path" -Filter "Backup-*-SMBSec-*.xml"
+        $files | ForEach-Object { Remove-Item $_.FullName -Force }
+    }   
 }

--- a/tests/Process.Tests.ps1
+++ b/tests/Process.Tests.ps1
@@ -286,5 +286,16 @@ Describe 'Remove a DACL' {
 
 AfterAll {
     Restore-SMBSecurity -File $Script:backup
-    Remove-Item $Script:backup -Force
+    
+    # do file cleanup so it doesn't interfere with other tests
+    $paths = "C:\Temp",  "$ENV:LOCALAPPDATA\SMBSecurity"
+
+    foreach ($path in $paths)
+    {
+        $files = Get-ChildItem "$path" -Filter "SMBSec-*.reg"
+        $files | ForEach-Object { Remove-Item $_.FullName -Force }
+
+        $files = Get-ChildItem "$path" -Filter "Backup-*-SMBSec-*.xml"
+        $files | ForEach-Object { Remove-Item $_.FullName -Force }
+    }   
 }

--- a/tests/Set.Tests.ps1
+++ b/tests/Set.Tests.ps1
@@ -179,5 +179,16 @@ Describe 'Set-SMBSecurityDACL and Set-SmbSecurityDescriptorDACL' {
 
 AfterAll {
     Restore-SMBSecurity -File $Script:backup
-    Remove-Item $Script:backup -Force
+    
+    # do file cleanup so it doesn't interfere with other tests
+    $paths = "C:\Temp",  "$ENV:LOCALAPPDATA\SMBSecurity"
+
+    foreach ($path in $paths)
+    {
+        $files = Get-ChildItem "$path" -Filter "SMBSec-*.reg"
+        $files | ForEach-Object { Remove-Item $_.FullName -Force }
+
+        $files = Get-ChildItem "$path" -Filter "Backup-*-SMBSec-*.xml"
+        $files | ForEach-Object { Remove-Item $_.FullName -Force }
+    }   
 }


### PR DESCRIPTION
Added the following parameters to Save-SMBSecurity:

- BackupPath - Backs up files to this path rather than the automatic backup path.
- BackupWithRegFile - Also creates a complete backup using a registry export of the SMB SecurityDescriptors.

Added the following parameter to Backup-SMBSecurity:

- FilePassThru - Returns a [string[]] (string array) containing the full path to all backup files created. This eases automation a bit when testing whether a backup was successful or when moving backup files to a central location.

Added more tests to Misc.Tests.ps1 which cover the new parameters.

Added better cleanup to Pester tests to ensure residual files do not interfere with testing.