### PR TITLE
WS2016 fixes + SessInfo Remediation

### DIFF
--- a/bin/class.ps1
+++ b/bin/class.ps1
@@ -969,7 +969,7 @@ class SMBSecDaclAce
     [SMBSecurityDescriptor]$SecurityDescriptor
     [SMBSecAccount]$Account
     [SMBSecAccess]$Access
-    [string[]]$Right # permission control will be handled by the functions and methods
+    [array]$Right # permission control will be handled by the functions and methods
 
     ## constructors ##
     #region 
@@ -977,11 +977,14 @@ class SMBSecDaclAce
     SMBSecDaclAce([SMBSecurityDescriptor]$SecDesc)
     {
         Write-Verbose "[SMBSecDaclAce] - Begin"
-        Write-Verbose "[SMBSecDaclAce] - Creating class with SecDesc"
+        Write-Verbose "[SMBSecDaclAce] - Creating class with SecDesc only: $SecDesc"
         $this.SecurityDescriptor = $SecDesc
-        $this.Account            = $null
+        Write-Verbose "[SMBSecDaclAce] - Default to Administrators"
+        $this.Account            = [SMBSecAccount]::new('BUILTIN\Administrators')
+        Write-Verbose "[SMBSecDaclAce] - Default to Deny"
         $this.Access             = "Deny"
-        $this.Right              = $null
+        Write-Verbose "[SMBSecDaclAce] - Default to FullControl"
+        $this.Right              = 'FullControl'
         Write-Verbose "[SMBSecDaclAce] - End"
     }
 
@@ -1139,9 +1142,10 @@ class SMBSecDaclAce
         # if FullControl is part of the permissions, set that and break because the rest don't matter
         if ($Right -contains "FullControl")
         {
-            $this.Right = "FullControl"
+            $r = "FullControl" 
+            $this.Right = $r
             Write-Verbose "[SMBSecDaclAce] - SetRight: Set to FullControl. Ignoring other rights."
-            break
+            return
         }
 
         # validate the rights match the SecDesc


### PR DESCRIPTION
Updates:

- Added a Type Accelerator to load classes and enums into the PS runspace.
- Fixes some bugs with Windows Server 2016.
- Added a remediation script:
  - Removes Authenticated Users from the SrvsvcSessionInfo security descriptor.
  - Exports the DefaultSecurity regsitry key.
  - Converts the binary data for SrvsvcSessionInfo to a string that can be used by a registry GPO.
  - Outputs details once done.

Sample output:

```powershell
 .\Remove-SessionInfoAuthenticatedUsers.ps1
Authenticated Users was removed from the SrvsvcSessionInfo security descriptor. The currect rights are:
SecurityDescriptor Account                Access Right
------------------ -------                ------ -----
 SrvsvcSessionInfo BUILTIN\Administrators  Allow {FullControl}
 SrvsvcSessionInfo Server Operators        Allow {FullControl}
 SrvsvcSessionInfo BUILTIN\Power Users     Allow {FullControl}

The operation completed successfully.

The backup file is located at: C:\Users\Administrator\AppData\Local\SMBSecurity\Backup-SrvsvcSessionInfo-SMBSec-20032025-1204563915.xml

The updated DefaultSecurity key has been exported to: C:\Scripts\SMBSecurity\Remediation\SMBSecurityDescriptors.reg

The binary string for the updated SrvsvcSessionInfo registry value is:
104128...<snip>
```